### PR TITLE
Add factory config

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,23 @@ to a string, the declared `run()` method will be called.
 <?= MyWidget::widget() ?>
 ```
 
-The `Yiisoft\Widget\WidgetFactory` factory uses a [PSR-11 Container](https://github.com/php-fig/container)
-instance to create widget objects, so you can require dependencies by listing them in your widget's constructor.
-To initialize the widget factory call `WidgetFactory::initialize()` once before using widgets.
+The `Yiisoft\Widget\WidgetFactory` factory uses a [Factory](https://github.com/yiisoft/factory)
+instance to create widget objects, so you can require dependencies by listing them in your widget's constructor
+and set default values when initializing the factory. To initialize the widget factory call
+`WidgetFactory::initialize()` once before using widgets:
 
 ```php
 /**
  * @var \Psr\Container\ContainerInterface $container
  */
+ 
+$widgetDefaults = [
+    MyWidget::class => [
+        'withNumber()' => [42],
+    ],
+];
 
-\Yiisoft\Widget\WidgetFactory::initialize($container);
+\Yiisoft\Widget\WidgetFactory::initialize($container, $widgetDefaults);
 ```
 
 It is a good idea to do that for the whole application. See Yii example in the configuration file of this package

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,8 @@
             "source-directory": "config"
         },
         "config-plugin": {
-            "bootstrap": "bootstrap.php"
+            "bootstrap": "bootstrap.php",
+            "widgets": "widgets.php"
         }
     },
     "scripts": {

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 use Psr\Container\ContainerInterface;
 use Yiisoft\Widget\WidgetFactory;
+use Yiisoft\Config\Config;
+
+/** @var $config Config */
 
 return [
-    static function (ContainerInterface $container) {
-        WidgetFactory::initialize($container);
+    function (ContainerInterface $container) use ($config) {
+        WidgetFactory::initialize($container, $config->get('widgets'));
     },
 ];

--- a/config/widgets.php
+++ b/config/widgets.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+return [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | 

Factory config for widgets allows to set default values and moves widgets out of DI container. It is now impossible to configure widgets with DI container (for the better).

TODO:

- [x] Add docs.
- [x] Adopt in app: https://github.com/yiisoft/widget/pull/44
- [x] Adopt in demo: https://github.com/yiisoft/demo/pull/379
