### PR TITLE
Allow to return `\Stringable` object in methods `Widget::run()` and `Widget::afterRun()`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,10 @@ indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
 
+[*.php]
+ij_php_space_before_short_closure_left_parenthesis = false
+ij_php_space_after_type_cast = true
+
 [*.md]
 trim_trailing_whitespace = false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.1 under development
 
-- no changes in this release.
+- Enh #73: Allow to return `\Stringable` object in methods `Widget::run()` and `Widget::afterRun()` (@vjik) 
 
 ## 1.1.0 November 08, 2022
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ In order to implement your own widget, you need to create a class that extends t
 ```php
 final class MyWidget extends \Yiisoft\Widget\Widget
 {
-    protected function run(): string
+    protected function run(): string|\Stringable
     {
         return 'My first widget.'.
     }
@@ -172,7 +172,7 @@ The `afterRun()` method is called right after running the widget. The return val
 as the widget return value. If you override this method, your code should look like the following:
 
 ```php
-protected function afterRun(string $result): string
+protected function afterRun(string $result): string|\Stringable
 {
     $result = parent::afterRun($result);
     // your custom code here

--- a/src/Widget.php
+++ b/src/Widget.php
@@ -107,7 +107,7 @@ abstract class Widget implements NoEncodeStringableInterface, Stringable
             return '';
         }
 
-        return $this->afterRun($this->run());
+        return (string) $this->afterRun((string) $this->run());
     }
 
     /**
@@ -128,7 +128,7 @@ abstract class Widget implements NoEncodeStringableInterface, Stringable
      * This method is used by {@see render()} and is meant to be overridden
      * when implementing concrete widget.
      */
-    abstract protected function run(): string;
+    abstract protected function run(): string|Stringable;
 
     /**
      * This method is invoked right before the widget is executed.
@@ -175,9 +175,9 @@ abstract class Widget implements NoEncodeStringableInterface, Stringable
      *
      * @param string $result The widget return result.
      *
-     * @return string The processed widget result.
+     * @return string|Stringable The processed widget result.
      */
-    protected function afterRun(string $result): string
+    protected function afterRun(string $result): string|Stringable
     {
         return $result;
     }

--- a/src/Widget.php
+++ b/src/Widget.php
@@ -165,7 +165,7 @@ abstract class Widget implements NoEncodeStringableInterface, Stringable
      * If you override this method, your code should look like the following:
      *
      * ```php
-     * protected function afterRun(string $result): string
+     * protected function afterRun(string $result): string|\Stringable
      * {
      *     $result = parent::afterRun($result);
      *     // your custom code here

--- a/tests/Stubs/StringableObject.php
+++ b/tests/Stubs/StringableObject.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Widget\Tests\Stubs;
+
+use Stringable;
+
+final class StringableObject implements Stringable
+{
+    public function __construct(private $string = '')
+    {
+    }
+
+    public function __toString(): string
+    {
+        return $this->string;
+    }
+}

--- a/tests/Stubs/StringableWidget.php
+++ b/tests/Stubs/StringableWidget.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Widget\Tests\Stubs;
+
+use Stringable;
+use Yiisoft\Widget\Widget;
+
+final class StringableWidget extends Widget
+{
+    protected function run(): Stringable
+    {
+        return new StringableObject('run');
+    }
+
+    protected function afterRun(string $result): Stringable
+    {
+        return new StringableObject('after-' . parent::afterRun($result));
+    }
+}

--- a/tests/WidgetTest.php
+++ b/tests/WidgetTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use RuntimeException;
 use Yiisoft\Test\Support\Container\SimpleContainer;
+use Yiisoft\Widget\Tests\Stubs\StringableWidget;
 use Yiisoft\Widget\Tests\Stubs\TestWidgetAfterRender;
 use Yiisoft\Widget\Tests\Stubs\TestWidgetBeforeRenderFalse;
 use Yiisoft\Widget\Tests\Stubs\ImmutableWidget;
@@ -188,5 +189,12 @@ final class WidgetTest extends TestCase
 
         $this->assertSame('Failed to create a widget because WidgetFactory is not initialized.', $exception->getName());
         $this->assertStringContainsString('`WidgetFactory::initialize()`', $exception->getSolution());
+    }
+
+    public function testStringable(): void
+    {
+        $widget = StringableWidget::widget();
+
+        $this->assertSame('after-run', $widget->render());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | #64 